### PR TITLE
Adds a new decorator called verify_authorized_or_policy_scoped which …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+venv2/
+venv3/
+
 .DS_Store
 tags
 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
+  - "3.6"
+  - "3.7"
 install:
   - pip install -r requirements.txt
-  - pip install pep8
+  - pip install pycodestyle
 before_script:
-  - pep8 .
+  - pycodestyle .
 script: nosetests

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -2,7 +2,9 @@ from flask import g, Flask
 from flask_pundit import (
     FlaskPundit,
     verify_authorized,
-    verify_policy_scoped)
+    verify_policy_scoped,
+    verify_authorized_or_policy_scoped
+)
 from .models.post import Post
 from .models.comment import Comment
 from nose.tools import (
@@ -211,6 +213,49 @@ class TestUsage(TestCase):
 
         @self.app.route('/test_policy_scope_admin')
         @verify_policy_scoped
+        def admin_get_post():
+            g.user = {'id': 1, 'role': 'admin'}
+            return json.dumps({'posts': []})
+        assert_raises(RuntimeError, self.client.get,
+                      '/test_policy_scope_admin')
+
+    def test_verify_authorized_or_policy_scope_decorator_success_with_authorize(self):
+        def do_authorize_stuff():
+            post = Post(1)
+            return self.pundit.authorize(post)
+
+        @self.app.route('/test_authorize_admin_get')
+        @verify_authorized_or_policy_scoped
+        def admin_get_post():
+            g.user = {'id': 1, 'role': 'admin'}
+            raise BadRequest()
+            is_authorized = do_authorize_stuff()
+            if is_authorized:
+                return 'Success', 200
+            else:
+                return 'Forbidden', 403
+        resp = self.client.get('/test_authorize_admin_get')
+        eq_(resp.status_code, 400)
+
+    def test_verify_authorized_or_policy_scoped_decorator_success_with_scope(self):
+        def do_policy_scope_stuff():
+            return self.pundit.policy_scope(Post)
+
+        @self.app.route('/test_policy_scope_admin')
+        @verify_authorized_or_policy_scoped
+        def admin_get_post():
+            g.user = {'id': 1, 'role': 'admin'}
+            scoped_posts = do_policy_scope_stuff()
+            return json.dumps({'posts': scoped_posts})
+        resp = self.client.get('/test_policy_scope_admin')
+        eq_(resp.data.decode(), '{"posts": [1, 2]}')
+
+    def test_verify_authorized_or_policy_scoped_decorator_raises_exception(self):
+        def do_policy_scope_stuff():
+            return self.pundit.policy_scope(Post)
+
+        @self.app.route('/test_policy_scope_admin')
+        @verify_authorized_or_policy_scoped
         def admin_get_post():
             g.user = {'id': 1, 'role': 'admin'}
             return json.dumps({'posts': []})

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -219,7 +219,7 @@ class TestUsage(TestCase):
         assert_raises(RuntimeError, self.client.get,
                       '/test_policy_scope_admin')
 
-    def test_verify_authorized_or_policy_scope_decorator_success_with_authorize(self):
+    def test_verify_either_decorator_success_with_authorize(self):
         def do_authorize_stuff():
             post = Post(1)
             return self.pundit.authorize(post)
@@ -237,7 +237,7 @@ class TestUsage(TestCase):
         resp = self.client.get('/test_authorize_admin_get')
         eq_(resp.status_code, 400)
 
-    def test_verify_authorized_or_policy_scoped_decorator_success_with_scope(self):
+    def test_verify_either_decorator_success_with_scope(self):
         def do_policy_scope_stuff():
             return self.pundit.policy_scope(Post)
 
@@ -250,7 +250,7 @@ class TestUsage(TestCase):
         resp = self.client.get('/test_policy_scope_admin')
         eq_(resp.data.decode(), '{"posts": [1, 2]}')
 
-    def test_verify_authorized_or_policy_scoped_decorator_raises_exception(self):
+    def test_verify_either_decorator_raises_exception(self):
         def do_policy_scope_stuff():
             return self.pundit.policy_scope(Post)
 


### PR DESCRIPTION
New decorator called verify_authorized_or_policy_scoped which is just like the two default decorators, but it allows either one of the methods (`authorize` or `policy_scope`) to be called without throwing the RuntimeError.